### PR TITLE
Fix zoom, part 1

### DIFF
--- a/src/lobjects/laxis.jl
+++ b/src/lobjects/laxis.jl
@@ -739,6 +739,12 @@ function add_zoom!(scene::SceneLike, limits, xzoomlock, yzoomlock, xzoomkey, yzo
             newwidth = ifelse.(this_zoomlock, _widths, _widths .* z)
             neworigin = ifelse.(this_zoomlock, origin, origin .+ mp_fraction .* (_widths .- newwidth))
 
+            fclamp(x) = clamp(x, floatmin(typeof(x)), floatmax(typeof(x)))
+            posfclamp(x) = clamp(x, eps(typeof(x))^2 #=some tiny=# , floatmax(typeof(x)))
+
+            newwidth = fclamp.(newwidth)
+            neworigin = fclamp.(neworigin)
+
             # splatting is not yet fast for StaticArrays: https://github.com/JuliaArrays/StaticArrays.jl/issues/361
             limits[] = FRect(Tuple(neworigin)..., Tuple(newwidth)...)
         end


### PR DESCRIPTION
First thing I did to try this package

```julia
import MakieLayout: LAxis, layoutscene
import MakieLayout

scene, layout = layoutscene(1, 1, 30, resolution = (1200, 1200))
layout[1,1] = LAxis(scene, title="hi")

scene
```

Owing to the refreshing responsiveness of the zooming and scrolling, I near immediately scrolled to troubleland, related to calculating ticks when the extents are infinity and/or the widths are near-zero. This PR doesn't fix all of the issues, and I'm not sure the best way to fix the remaining issues. Basically the tick functions need to be allowed to return some degenerate thing (e.g. [x, x] for some x, two repeated tick positions).

This PR includes some aesthetic changes too. I personally strongly prefer relying on broadcasting as much as possible, to reduce duplicated lines across dimensions (even for 2 dimensions). But I'll take those changes out if you prefer.

Thanks for this package!